### PR TITLE
name funcitons using labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ To specify any function, use the builtin constructor `Function`.
 
 Return types must be specified.
 
-Functions may be named by preceeding the parentheses with the function name. When written as a comment above the funciton definition, this is typically omitted.
+Functions may be named by adding a label infront of the function definition.
+  When written as a comment above the funciton definition,
+  this is typically omitted.
 
-    getElementById(String) => DOMElement
+    getElementById: (String) => DOMElement
 
 #### Parameters
 


### PR DESCRIPTION
Any type can be labeled using the labeling syntax.
We should favor labeling function over the named function
syntax.

This is kind of like only using `var foo = function () {}`
and no function declarations.

Favoring the label syntax removes a permutation from jsig
and simplifies it.

cc @jden @Matt-Esch
