### PR TITLE
Update return values to demonstrate compound types

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,17 @@ When a function accepts an arbitrary number of parameters of the same type, they
 
 #### Return types
 
-Functions should return a single type, indicated after the arrow notation, eg `() => Type`. If a function returns different types depending on the parameters, this should be explicitly noted and each function signature should be fully specified:
+Functions should return a single type, indicated after the arrow notation, eg `() => Type`. 
 
-    fooAsync(callback: Function) => void
-    fooAsync() => Promise
+If a function returns different types depending on the parameters, this should be explicitly noted and each function signature should be fully specified:
 
+    fooAsync: (callback: Function) => void &
+        () => Promise
+
+Note that we can use a compound type to specify that `fooAsync`
+  supports both the callback interface and the promise interface.
+
+This is similar to method overloading in static languages.
 
 Functions which do not return a type should be specified as `() => void`
 


### PR DESCRIPTION
I've changed the named function into a labeled function.

This again simplifies jsig so that there are only
    labeled types and not named types.

I've removed explicit function overloading, you cannot
    define the same label or named function multiple
    times.

Instead you can use the compound type syntax that already
    exists to state that the label `fooAsync` implements
    both signatures.

This simplifies jsig so that there are only compound
    types and not function overloading.

cc @jden @Matt-Esch
