### PR TITLE
remove optional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Functions which do not return a type should be specified as `() => void`
 
 ### Optional
 
-When describing a function's parameters list, an optional parameter can be specified by appending a question mark `?` to either the parameter name (if named) or the type annotation:
+When describing a function's parameters list, an optional parameter can be specified by appending a question mark `?` to the parameter name:
 
-    // (requestUrl: String, timeout: Number?) => Promise<String>
+    // (requestUrl: String, timeout?: Number) => Promise<String>
     function get(requestUrl, timeout) {
       // do stuff
     }


### PR DESCRIPTION
An optional type can either have an optional label or be
    an optional type.

Let's compare

``` jsig
foo : (A, B?, C) => void

foo2 : (A, b?: B, C) => void
```

There is a difference between an optional type and an
    optional label.

An optional label means the argument is optional.

i.e. `foo2(A, C)` is valid.

An optional type means the type `B` is nullable

i.e. `foo(A, null, C)` is valid.

Most of the time when you think optional what you really
    mean is an optional argument.

It's recommended that if you truly want a nullable type
    you be more explicit about it. i.e.

`foo3 : (A, B | null, C) => void`

This PR removes optional types completely and tells you
    to use optional labels.

cc @jden @Matt-Esch
