### PR TITLE
Correct a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ type HttpServerRequest : {
   url: String
 }
 
-endpoint : (req; HttpServerRequest, res: HttpServerResponse) => void
+endpoint : (req: HttpServerRequest, res: HttpServerResponse) => void
 ```
 
 Custom types can be named like function parameters using the `type` keyword and a colon character `:`, and should use PascalCase:


### PR DESCRIPTION
I'm pretty sure that that `;` was meant to be a `:` ;)